### PR TITLE
Windows with NoResize

### DIFF
--- a/RestoreWindowPlace/WindowPlace.cs
+++ b/RestoreWindowPlace/WindowPlace.cs
@@ -117,5 +117,35 @@ namespace RestoreWindowPlace
         {
             Register(window, typeof(T).Name);
         }
+
+        /// <summary>
+        /// Register the event that store/restore position of Window automatically
+        /// using unique ID
+        /// </summary>
+        /// <param name="window">target window</param>
+        /// <param name="windowId">Unique ID associated with the window</param>
+        /// <remarks>The size of the window is not restored.</remarks>
+        public void RegisterPositionOnly(Window window, string windowId)
+        {
+            window.SourceInitialized += (o, e) => this.RestorePosition(window, windowId);
+            window.Closing += (o, e) =>
+            {
+                if (!e.Cancel)
+                {
+                    this.Store(window, windowId);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Register the event that store/restore position of Window automatically
+        /// using the name of the type extends Window class
+        /// </summary>
+        /// <param name="window">target window</param>
+        /// <remarks>The size of the window is not restored.</remarks>
+        public void RegisterPositionOnly<T>(T window) where T : Window
+        {
+            RegisterPositionOnly(window, typeof(T).Name);
+        }
     }
 }

--- a/RestoreWindowPlace/WindowRelocate.cs
+++ b/RestoreWindowPlace/WindowRelocate.cs
@@ -14,8 +14,10 @@ namespace RestoreWindowPlace
         /// Set position and size to window
         /// </summary>
         /// <param name="windowHandle"></param>
-        /// <param name="positon">Position and size. If width &lt; 0 maximized, if height &lt; 0 minimized.</param>
-        public static void Relocate(IntPtr windowHandle, Rectangle positon)
+        /// <param name="position">
+        /// Position and size. If width &lt; 0 maximized, if height &lt; 0 minimized. If height and width are 0 ignore size
+        /// </param>
+        public static void Relocate(IntPtr windowHandle, Rectangle position)
         {
             var placement = new WindowPlacement.WINDOWPLACEMENT();
 
@@ -24,10 +26,13 @@ namespace RestoreWindowPlace
             // Get current placement
             WindowPlacement.GetWindowPlacement(windowHandle, ref placement);
 
+            var normalWidth = placement.NormalPosition.Width;
+            var normalHeight = placement.NormalPosition.Height;
+
             placement.ShowCmd = WindowPlacement.ShowWindowCommands.Restore;
             placement.Flags = 0;
-            placement.NormalPosition.Top = positon.Top;
-            placement.NormalPosition.Left = positon.Left;
+            placement.NormalPosition.Top = position.Top;
+            placement.NormalPosition.Left = position.Left;
 
             ////Restore if minimized
             //if (placement.ShowCmd == WindowPlacement.ShowWindowCommands.ShowMinimized)
@@ -35,13 +40,14 @@ namespace RestoreWindowPlace
             //    placement.ShowCmd = WindowPlacement.ShowWindowCommands.Normal;
             //}
 
-            var width = positon.Width;
-            var height = positon.Height;
+            var width = position.Width;
+            var height = position.Height;
 
             if (width == 0 || height == 0)
             {
-                width = placement.NormalPosition.Right - placement.NormalPosition.Left;
-                height = placement.NormalPosition.Bottom - placement.NormalPosition.Top;
+                // ignoring size
+                width = normalWidth;
+                height = normalHeight;
             }
             else if (width < 0 && height < 0)
             {

--- a/RestoreWindowPlaceTest.Net/MainWindow.xaml.cs
+++ b/RestoreWindowPlaceTest.Net/MainWindow.xaml.cs
@@ -24,9 +24,6 @@ namespace RestoreWindowPlaceTest.Net
         {
             InitializeComponent();
 
-            // Save setting when this window close
-            this.Closed += (o, e) => ((App)Application.Current).WindowPlace.Save();
-
             // Resister the window using type name as key
             ((App)Application.Current).WindowPlace.Register(this);
 

--- a/RestoreWindowPlaceTest/MainWindow.xaml.cs
+++ b/RestoreWindowPlaceTest/MainWindow.xaml.cs
@@ -24,9 +24,6 @@ namespace RestoreWindowPlaceTest
         {
             InitializeComponent();
 
-            // Save setting when this window close
-            this.Closed += (o, e) => ((App)Application.Current).WindowPlace.Save();
-
             // Resister the window using type name as key
             ((App)Application.Current).WindowPlace.Register(this);
 


### PR DESCRIPTION
Thanks for your repo! 

When a window has a fixed size the current code does not restore the size correctly (even when specifying that we only want the position to be restored). The attached update fixes the calculation and also provides another Register method to use when we only want to restore the position.