### PR TITLE
Add support to check if key is already registered.

### DIFF
--- a/RestoreWindowPlace/WindowPlace.cs
+++ b/RestoreWindowPlace/WindowPlace.cs
@@ -117,5 +117,16 @@ namespace RestoreWindowPlace
         {
             Register(window, typeof(T).Name);
         }
+
+        /// <summary>
+        /// Checks if key is registered.
+        /// </summary>
+        /// <param name="window"></param>
+        /// <param name="key"></param>
+        public bool IsRegistered(string key)
+        {
+            return this.windowPlaces.TryGetValue(key, out _);
+        }
+
     }
 }


### PR DESCRIPTION
Needed to allow for custom window behavior if the window is not registered in the window place Dictionary (for example the first time a window is opened).